### PR TITLE
Fixed downloads from Dataverse not working

### DIFF
--- a/pdebench/data_download/download.py
+++ b/pdebench/data_download/download.py
@@ -5,9 +5,7 @@ from hydra.utils import get_original_cwd
 from omegaconf import DictConfig
 import logging
 
-from pyDataverse.api import NativeApi, DataAccessApi
-from pyDaRUS import Dataset
-from easyDataverse.core.downloader import download_files
+from easyDataverse import Dataset
 
 log = logging.getLogger(__name__)
 
@@ -26,23 +24,12 @@ def main(config: DictConfig):
     os.chdir(get_original_cwd())
 
     # Extract dataset from the given DOI
-    dataset = Dataset()
-    setattr(dataset, "p_id", config.args.dataset_id)
-
-    # Extract file list contained in the dataset
-    api = NativeApi(config.args.dataverse_url)
-    data_api = DataAccessApi(config.args.dataverse_url)
-    dv_dataset = api.get_dataset(config.args.dataset_id)
-    files_list = dv_dataset.json()["data"]["latestVersion"]["files"]
-
-    # Compile list of files that matches the desired filename
-    files = []
-    for i, file in enumerate(files_list):
-        if config.args.filename in file["dataFile"]["filename"]:
-            files.append(file)
-
-    # Download the files
-    download_files(data_api, dataset, files, os.path.abspath(config.args.data_folder))
+    dataset = Dataset.from_dataverse_doi(
+        doi=config.args.dataset_id,
+        dataverse_url=config.args.dataverse_url,
+        filenames=[config.args.filename],
+        filedir=config.args.data_folder,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request integrates EasyDataverse to download files from a given dataset. Beforehand a mixture of pyDataverse and EasyDataverse was used, but since the latter is based on the former, the code can be reduced accordingly. The current code fetches a dataset from Dataverse and downloads files that match the ```filenames``` entries to the specified directory.

Please note that I have used the development version of [EasyDataverse](https://github.com/gdcc/easyDataverse), which supports the download of specific files, as it was done in your code. 