### PR TITLE
Add workaround for parallel HDF5 writing

### DIFF
--- a/pdebench/data_gen/gen_diff_react.py
+++ b/pdebench/data_gen/gen_diff_react.py
@@ -48,24 +48,33 @@ def simulator(config, i):
 
     seed_str = str(i).zfill(4)
     
-    with h5py.File(utils.expand_path(config.output_path), "a") as data_f:
-        ## Chunking for compression and data access
-        ## https://docs.h5py.org/en/stable/high/dataset.html#chunked-storage
-        ## should be by batch and less than 1MB
-        ## lzf compression for float32 is kind of pointless though.
-        data_f.create_dataset(
-            f"{seed_str}/data", data=data_sample, dtype="float32", compression="lzf"
-        )
-        data_f.create_dataset(
-            f"{seed_str}/grid/x", data = sim_obj.x, dtype="float32", compression="lzf"
-        )
-        data_f.create_dataset(
-            f"{seed_str}/grid/y", data=sim_obj.y, dtype="float32", compression="lzf" 
-        )
-        data_f.create_dataset(
-            f"{seed_str}/grid/t", data=sim_obj.t, dtype="float32", compression="lzf" 
-        )
-        data_f.attrs[f"{seed_str}/config"] = OmegaConf.to_yaml(config)
+    while True:
+        try:
+            with h5py.File(utils.expand_path(config.output_path), "a") as data_f:
+                ## Chunking for compression and data access
+                ## https://docs.h5py.org/en/stable/high/dataset.html#chunked-storage
+                ## should be by batch and less than 1MB
+                ## lzf compression for float32 is kind of pointless though.
+                data_f.create_dataset(
+                    f"{seed_str}/data", data=data_sample, dtype="float32", compression="lzf"
+                )
+                data_f.create_dataset(
+                    f"{seed_str}/grid/x", data = sim_obj.x, dtype="float32", compression="lzf"
+                )
+                data_f.create_dataset(
+                    f"{seed_str}/grid/y", data=sim_obj.y, dtype="float32", compression="lzf" 
+                )
+                data_f.create_dataset(
+                    f"{seed_str}/grid/t", data=sim_obj.t, dtype="float32", compression="lzf" 
+                )
+                data_f.attrs[f"{seed_str}/config"] = OmegaConf.to_yaml(config)
+        except IOError:
+            time.sleep(0.1)
+            continue
+        else:
+            break
+
+    
 
 
 @hydra.main(config_path="configs/", config_name="diff-react")

--- a/pdebench/data_gen/gen_diff_sorp.py
+++ b/pdebench/data_gen/gen_diff_sorp.py
@@ -48,22 +48,31 @@ def simulator(config, i):
     log.info(f"Seed {config.sim.seed} took {duration} to finish")
         
     seed_str = str(i).zfill(4)
+
+    while True:
+        try:
+            with h5py.File(utils.expand_path(config.output_path), "a") as data_f:
+                ## Chunking for compression and data access
+                ## https://docs.h5py.org/en/stable/high/dataset.html#chunked-storage
+                ## should be by batch and less than 1MB
+                ## lzf compression for float32 is kind of pointless though.
+                data_f.create_dataset(
+                    f"{seed_str}/data", data=data_sample, dtype="float32", compression="lzf"
+                )
+                data_f.create_dataset(
+                    f"{seed_str}/grid/x", data = sim_obj.x, dtype="float32", compression="lzf"
+                )
+                data_f.create_dataset(
+                    f"{seed_str}/grid/t", data=sim_obj.t, dtype="float32", compression="lzf" 
+                )
+                data_f.attrs[f"{seed_str}/config"] = OmegaConf.to_yaml(config)
+        except IOError:
+            time.sleep(0.1)
+            continue
+        else:
+            break
     
-    with h5py.File(utils.expand_path(config.output_path), "a") as data_f:
-        ## Chunking for compression and data access
-        ## https://docs.h5py.org/en/stable/high/dataset.html#chunked-storage
-        ## should be by batch and less than 1MB
-        ## lzf compression for float32 is kind of pointless though.
-        data_f.create_dataset(
-            f"{seed_str}/data", data=data_sample, dtype="float32", compression="lzf"
-        )
-        data_f.create_dataset(
-            f"{seed_str}/grid/x", data = sim_obj.x, dtype="float32", compression="lzf"
-        )
-        data_f.create_dataset(
-            f"{seed_str}/grid/t", data=sim_obj.t, dtype="float32", compression="lzf" 
-        )
-        data_f.attrs[f"{seed_str}/config"] = OmegaConf.to_yaml(config)
+    
 
 
 @hydra.main(config_path="configs/", config_name="diff-sorp")

--- a/pdebench/data_gen/src/sim_diff_react.py
+++ b/pdebench/data_gen/src/sim_diff_react.py
@@ -149,6 +149,6 @@ class Simulator:
         y_t = np.concatenate((u_t,v_t))
         
         # Log the simulation progress
-        self.log.info('t = ' + str(t))
+        # self.log.info('t = ' + str(t))
        
         return y_t

--- a/pdebench/data_gen/src/sim_diff_sorp.py
+++ b/pdebench/data_gen/src/sim_diff_sorp.py
@@ -124,6 +124,6 @@ class Simulator:
         y_t = c_t
         
         # Log the simulation progress
-        self.log.info('t = ' + str(t))
+        # self.log.info('t = ' + str(t))
        
         return y_t

--- a/pdebench/data_gen/src/sim_radial_dam_break.py
+++ b/pdebench/data_gen/src/sim_radial_dam_break.py
@@ -90,13 +90,11 @@ class Basic2DScenario(ABC):
         for key, getter in self.state_getters.items():
             self.save_state[key] = [getter()]
 
-    def save_state_to_disk(self, data_f, seed):
+    def save_state_to_disk(self, data_f, seed_str):
         T = np.asarray(self.save_state["t"])
         X = np.asarray(self.save_state["x"])
         Y = np.asarray(self.save_state["y"])
         H = np.expand_dims(np.asarray(self.save_state["h"]), -1)
-        
-        seed_str = str(seed).zfill(4)
 
         data_f.create_dataset(f"{seed_str}/data", data=H, dtype="f")
         data_f.create_dataset(f"{seed_str}/grid/x", data=X, dtype="f")
@@ -116,10 +114,10 @@ class Basic2DScenario(ABC):
         start = time.time()
         for tstep in range(1, tsteps + 1):
             t = tstep * dt
-            print("Simulating timestep {}/{} at t={:f}".format(tstep, tsteps, t))
+            # print("Simulating timestep {}/{} at t={:f}".format(tstep, tsteps, t))
             self.simulate(t)
             self.add_save_state()
-        print("Simulation took: {}".format(time.time() - start))
+        # print("Simulation took: {}".format(time.time() - start))
 
 
 class RadialDamBreak2D(Basic2DScenario):


### PR DESCRIPTION
This PR adds a workaround as proposed in #17 for parallel writing HDF5 files during data generation of the following models:
- diff_sorp
- diff_react
- radial_dam_break