### PR TITLE
Add missing base_path argument to Unet training

### DIFF
--- a/pdebench/models/train_models_forward.py
+++ b/pdebench/models/train_models_forward.py
@@ -215,6 +215,7 @@ def main(cfg: DictConfig):
             model_update=cfg.args.model_update,
             flnm=cfg.args.filename,
             single_file=cfg.args.single_file,
+            base_path=cfg.args.data_path,
             reduced_resolution=cfg.args.reduced_resolution,
             reduced_resolution_t=cfg.args.reduced_resolution_t,
             reduced_batch=cfg.args.reduced_batch,


### PR DESCRIPTION
Just adds a missing(?) argument to the unet training function call! Seems like everything is already setup to use this parameter. I can't store much in `../data`, so changing the `base_path` with the config is necessary. 
