### PR TITLE
Enable fast download mode (skip existing files)

### DIFF
--- a/pdebench/data_download/download_direct.py
+++ b/pdebench/data_download/download_direct.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import argparse
 from pathlib import Path
 
@@ -75,6 +76,13 @@ def download_data(root_folder, pde_name):
     # Iterate filtered dataframe and download the files
     for _, row in tqdm(pde_df.iterrows(), total=pde_df.shape[0]):
         file_path = Path(root_folder) / row["Path"]
+        if not no_fast_download:
+            try:
+                file_size = os.path.getsize(file_path)
+            except (FileNotFoundError, OSError):
+                file_size = 0
+            if file_size != 0:
+                pass
         download_url(row["URL"], file_path, row["Filename"], md5=row["MD5"])
 
 
@@ -95,6 +103,11 @@ if __name__ == "__main__":
         "--pde_name",
         action="append",
         help="Name of the PDE dataset to download. You can use this flag multiple times to download multiple datasets",
+    )
+    arg_parser.add_argument(
+        "--no_fast_download",
+        action="store_true",
+        help="Disable fast download mode, which skips files that are already downloaded",
     )
 
     args = arg_parser.parse_args()

--- a/pdebench/data_download/download_direct.py
+++ b/pdebench/data_download/download_direct.py
@@ -82,7 +82,7 @@ def download_data(root_folder, pde_name, no_fast_download=False):
             except (FileNotFoundError, OSError):
                 file_size = 0
             if file_size != 0:
-                pass
+                continue
         download_url(row["URL"], file_path, row["Filename"], md5=row["MD5"])
 
 

--- a/pdebench/data_download/download_direct.py
+++ b/pdebench/data_download/download_direct.py
@@ -78,10 +78,11 @@ def download_data(root_folder, pde_name, no_fast_download=False):
         file_path = Path(root_folder) / row["Path"]
         if not no_fast_download:
             try:
-                file_size = os.path.getsize(file_path)
+                file_size = os.path.getsize(file_path / row["Filename"])
             except (FileNotFoundError, OSError):
                 file_size = 0
             if file_size != 0:
+                # print(file_path / row["Filename"], file_size)
                 continue
         download_url(row["URL"], file_path, row["Filename"], md5=row["MD5"])
 

--- a/pdebench/data_download/download_direct.py
+++ b/pdebench/data_download/download_direct.py
@@ -59,7 +59,7 @@ def parse_metadata(pde_names):
     return meta_df[meta_df["PDE"].isin(pde_names)]
 
 
-def download_data(root_folder, pde_name):
+def download_data(root_folder, pde_name, no_fast_download=False):
     """ "
     Download data splits specific to a given PDE.
 
@@ -112,4 +112,4 @@ if __name__ == "__main__":
 
     args = arg_parser.parse_args()
 
-    download_data(args.root_folder, args.pde_name)
+    download_data(args.root_folder, args.pde_name, args.no_fast_download)


### PR DESCRIPTION
Network problems often cause errors and interruptions in downloads. Each time you download again, you will recheck the existing files. Repeated re-downloads will cause repeated checks, which is extremely time-consuming. Add the function of skipping existing files to speed up downloads.